### PR TITLE
Don't pkill icinga from a script called icinga

### DIFF
--- a/icinga/icinga
+++ b/icinga/icinga
@@ -102,7 +102,7 @@ icinga_stop() {
 
 icinga_stop_timeout() {
   ocf_log warn "Icinga took longer than 10 seconds to stop, killing it for good measure."
-  pkill -KILL icinga
+  pkill -KILL -f '^/usr/bin/icinga'
 }
 
 icinga_monitor() {


### PR DESCRIPTION
Calling pkill -KILL icinga from a OCF script called "icinga" also kills the script itself. Hardcoding a path to the icinga binary might not be perfect, but at least the script will not kill itself and return something non-zero this way.
